### PR TITLE
메모(Memo) 레코드 읽기/쓰기 지원 추가

### DIFF
--- a/src/hwplibsharp.test/ReadingWritingMemoTest.cs
+++ b/src/hwplibsharp.test/ReadingWritingMemoTest.cs
@@ -1,0 +1,120 @@
+using HwpLib.Object;
+using HwpLib.Reader;
+using HwpLib.Tool.BlankFileMaker;
+using HwpLib.Tool.TextExtractor;
+using HwpLib.Writer;
+using System.Text;
+
+namespace HwpLibSharp.Test;
+
+/// <summary>
+/// 메모(Memo) 읽기/쓰기 테스트 (이슈 #11)
+/// </summary>
+[TestClass]
+public class ReadingWritingMemoTest
+{
+    [TestMethod]
+    public void WriteAndReadMemo_ShouldPreserveMemoText()
+    {
+        // Arrange
+        var hwpFile = BlankFileMaker.Make();
+        Assert.IsNotNull(hwpFile);
+        AddMemo(hwpFile, 0, "첫 번째 메모입니다.");
+
+        // Act
+        var readFile = WriteAndRead(hwpFile);
+
+        // Assert
+        Assert.IsNotNull(readFile.BodyText.MemoList);
+        Assert.HasCount(1, readFile.BodyText.MemoList);
+
+        var memo = readFile.BodyText.MemoList[0];
+        Assert.AreEqual(0L, memo.MemoList.MemoIndex);
+        Assert.AreEqual(1, memo.ListHeader.ParaCount);
+        Assert.AreEqual("첫 번째 메모입니다.\n", memo.ParagraphList.GetNormalString());
+    }
+
+    [TestMethod]
+    public void WriteAndReadMultipleMemos_ShouldPreserveAll()
+    {
+        // Arrange
+        var hwpFile = BlankFileMaker.Make();
+        Assert.IsNotNull(hwpFile);
+        AddMemo(hwpFile, 0, "첫 번째 메모입니다.");
+        AddMemo(hwpFile, 1, "두 번째 메모입니다.");
+
+        // Act
+        var readFile = WriteAndRead(hwpFile);
+
+        // Assert
+        Assert.IsNotNull(readFile.BodyText.MemoList);
+        Assert.HasCount(2, readFile.BodyText.MemoList);
+        Assert.AreEqual(0L, readFile.BodyText.MemoList[0].MemoList.MemoIndex);
+        Assert.AreEqual(1L, readFile.BodyText.MemoList[1].MemoList.MemoIndex);
+        Assert.AreEqual("첫 번째 메모입니다.\n", readFile.BodyText.MemoList[0].ParagraphList.GetNormalString());
+        Assert.AreEqual("두 번째 메모입니다.\n", readFile.BodyText.MemoList[1].ParagraphList.GetNormalString());
+    }
+
+    [TestMethod]
+    public void ExtractTextFromMemo_ShouldReturnMemoText()
+    {
+        // Arrange
+        var hwpFile = BlankFileMaker.Make();
+        Assert.IsNotNull(hwpFile);
+        AddMemo(hwpFile, 0, "메모 본문 텍스트");
+
+        // Act
+        var readFile = WriteAndRead(hwpFile);
+
+        var sb = new StringBuilder();
+        foreach (var memo in readFile.BodyText.MemoList!)
+        {
+            ForParagraphList.Extract(
+                memo.ParagraphList,
+                TextExtractMethod.InsertControlTextBetweenParagraphText,
+                null,
+                sb);
+        }
+
+        // Assert
+        StringAssert.Contains(sb.ToString(), "메모 본문 텍스트");
+    }
+
+    /// <summary>
+    /// 문서에 메모를 추가한다.
+    /// </summary>
+    private static void AddMemo(HWPFile hwpFile, long memoIndex, string text)
+    {
+        var memo = hwpFile.BodyText.AddNewMemo();
+        memo.MemoList.MemoIndex = memoIndex;
+        memo.ListHeader.ParaCount = 1;
+        memo.ListHeader.TextWidth = 42520;
+        memo.ListHeader.TextHeight = 4252;
+
+        var paragraph = memo.ParagraphList.AddNewParagraph();
+        paragraph.Header.ParaShapeId = 1;
+        paragraph.Header.StyleId = 1;
+        paragraph.CreateText();
+        paragraph.Text?.AddString(text);
+        paragraph.CreateCharShape();
+        paragraph.CharShape?.AddParaCharShape(0, 2);
+    }
+
+    /// <summary>
+    /// 파일을 스트림에 쓴 뒤 다시 읽어서 반환한다.
+    /// </summary>
+    private static HWPFile WriteAndRead(HWPFile hwpFile)
+    {
+        byte[] bytes;
+        using (var ms = new MemoryStream())
+        {
+            HWPWriter.ToStream(hwpFile, ms);
+            bytes = ms.ToArray();
+        }
+
+        using var readStream = new MemoryStream(bytes);
+        var readFile = HWPReader.FromStream(readStream);
+        Assert.IsNotNull(readFile);
+        return readFile;
+    }
+}

--- a/src/hwplibsharp/Reader/BodyText/Control/ForParagraphList.cs
+++ b/src/hwplibsharp/Reader/BodyText/Control/ForParagraphList.cs
@@ -115,6 +115,15 @@ namespace HwpLib.Reader.BodyText.Control
                 else
                 {
                     SkipETCRecord();
+                    if (sr.IsImmediatelyAfterReadingHeader)
+                    {
+                        // 크기가 0인 레코드는 본문 읽기가 없어 헤더 플래그가 유지되므로,
+                        // 다음 헤더를 읽지 않으면 무한 루프에 빠진다
+                        if (!sr.ReadRecordHeader())
+                        {
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/src/hwplibsharp/Reader/BodyText/Memo/ForMemo.cs
+++ b/src/hwplibsharp/Reader/BodyText/Memo/ForMemo.cs
@@ -1,0 +1,45 @@
+// =====================================================================
+// Java Original: kr/dogfoot/hwplib/reader/bodytext/memo/ForMemo.java
+// Repository: https://github.com/neolord0/hwplib
+// =====================================================================
+
+using HwpLib.CompoundFile;
+using HwpLib.Object.BodyText.Paragraph.Memo;
+using HwpLib.Reader.BodyText.Control;
+
+namespace HwpLib.Reader.BodyText.Memo
+{
+    /// <summary>
+    /// 메모를 읽기 위한 객체
+    /// </summary>
+    public static class ForMemo
+    {
+        /// <summary>
+        /// 메모를 읽는다.
+        /// </summary>
+        /// <param name="m">메모 객체</param>
+        /// <param name="sr">스트림 리더</param>
+        public static void Read(Object.BodyText.Paragraph.Memo.Memo m, CompoundStreamReader sr)
+        {
+            ForMemoList.Read(m.MemoList, sr);
+            ListHeader(m.ListHeader, sr);
+            ForParagraphList.Read(m.ParagraphList, sr);
+        }
+
+        /// <summary>
+        /// 메모의 문단 리스트 헤더 레코드를 읽는다.
+        /// </summary>
+        /// <param name="listHeaderForMemo">메모의 문단 리스트 헤더 레코드</param>
+        /// <param name="sr">스트림 리더</param>
+        private static void ListHeader(ListHeaderForMemo listHeaderForMemo, CompoundStreamReader sr)
+        {
+            sr.ReadRecordHeader();
+
+            listHeaderForMemo.ParaCount = sr.ReadSInt4();
+            listHeaderForMemo.Property.Value = sr.ReadUInt4();
+            listHeaderForMemo.TextWidth = sr.ReadUInt4();
+            listHeaderForMemo.TextHeight = sr.ReadUInt4();
+            sr.SkipToEndRecord();
+        }
+    }
+}

--- a/src/hwplibsharp/Reader/BodyText/Memo/ForMemoList.cs
+++ b/src/hwplibsharp/Reader/BodyText/Memo/ForMemoList.cs
@@ -1,0 +1,25 @@
+// =====================================================================
+// Java Original: kr/dogfoot/hwplib/reader/bodytext/memo/ForMemoList.java
+// Repository: https://github.com/neolord0/hwplib
+// =====================================================================
+
+using HwpLib.CompoundFile;
+
+namespace HwpLib.Reader.BodyText.Memo
+{
+    /// <summary>
+    /// 메모 리스트 레코드를 읽기 위한 객체
+    /// </summary>
+    public static class ForMemoList
+    {
+        /// <summary>
+        /// 메모 리스트 레코드를 읽는다.
+        /// </summary>
+        /// <param name="ml">메모 리스트 레코드 객체</param>
+        /// <param name="sr">스트림 리더</param>
+        public static void Read(Object.BodyText.Paragraph.Memo.MemoList ml, CompoundStreamReader sr)
+        {
+            ml.MemoIndex = sr.ReadUInt4();
+        }
+    }
+}

--- a/src/hwplibsharp/Reader/HWPReader.cs
+++ b/src/hwplibsharp/Reader/HWPReader.cs
@@ -6,6 +6,7 @@
 using HwpLib.CompoundFile;
 using HwpLib.Object;
 using HwpLib.Object.DocInfo.BinData;
+using HwpLib.Object.Etc;
 using HwpLib.Object.FileHeader;
 using HwpLib.Reader.DocInfo;
 using System;
@@ -202,10 +203,10 @@ namespace HwpLib.Reader
                     })
                     .ToList();
 
-                foreach (var sectionName in sectionNames)
+                for (int i = 0; i < sectionNames.Count; i++)
                 {
                     var section = _hwpFile!.BodyText.AddNewSection();
-                    ReadSection(sectionName, section);
+                    ReadSection(sectionNames[i], section, i == sectionNames.Count - 1);
                 }
 
                 _cfr.MoveParentStorage();
@@ -217,12 +218,51 @@ namespace HwpLib.Reader
         /// </summary>
         /// <param name="sectionName">섹션 스트림 이름</param>
         /// <param name="section">섹션 객체</param>
-        private void ReadSection(string sectionName, HwpLib.Object.BodyText.Section section)
+        /// <param name="isLastSection">마지막 섹션인지 여부</param>
+        private void ReadSection(string sectionName, HwpLib.Object.BodyText.Section section, bool isLastSection)
         {
             using var sr = _cfr!.GetChildStreamReader(sectionName, IsCompressed(), GetVersion());
 
             // Section 스트림 읽기
             new BodyText.ForSection().Read(section, sr);
+
+            // 메모 레코드는 마지막 섹션 스트림의 끝에 붙어 있다
+            if (isLastSection)
+            {
+                ReadMemos(sr);
+            }
+        }
+
+        /// <summary>
+        /// 섹션 스트림 끝에 붙어 있는 메모 레코드들을 읽는다.
+        /// </summary>
+        /// <param name="sr">스트림 리더</param>
+        private void ReadMemos(CompoundStreamReader sr)
+        {
+            while (!sr.IsEndOfStream())
+            {
+                if (!sr.IsImmediatelyAfterReadingHeader)
+                {
+                    if (!sr.ReadRecordHeader())
+                    {
+                        break;
+                    }
+                }
+
+                if (sr.CurrentRecordHeader?.TagId == HWPTag.MemoList)
+                {
+                    BodyText.Memo.ForMemo.Read(_hwpFile!.BodyText.AddNewMemo(), sr);
+                }
+                else
+                {
+                    sr.SkipToEndRecord();
+                    if (sr.IsImmediatelyAfterReadingHeader)
+                    {
+                        // 크기가 0인 알 수 없는 레코드 - 무한 루프 방지
+                        break;
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/src/hwplibsharp/Writer/AutoSetter/AutoSetter.cs
+++ b/src/hwplibsharp/Writer/AutoSetter/AutoSetter.cs
@@ -43,6 +43,14 @@ namespace HwpLib.Writer.AutoSetter
             {
                 ForParagraphList.AutoSet(section, iid);
             }
+
+            if (bodyText.MemoList != null)
+            {
+                foreach (var memo in bodyText.MemoList)
+                {
+                    ForParagraphList.AutoSet(memo.ParagraphList, iid);
+                }
+            }
         }
     }
 }

--- a/src/hwplibsharp/Writer/HWPWriter.cs
+++ b/src/hwplibsharp/Writer/HWPWriter.cs
@@ -167,16 +167,14 @@ namespace HwpLib.Writer
 
             ForSection.Write(section, sw);
 
-            /*
             // 마지막 섹션에 메모 쓰기
             if (IsLastSection(index) && _hwpFile.BodyText.MemoList != null)
             {
                 foreach (var memo in _hwpFile.BodyText.MemoList)
                 {
-                    // TODO: ForMemo.Write(memo, sw);
+                    BodyText.Paragraph.Memo.ForMemo.Write(memo, sw);
                 }
             }
-            */
 
             _cfw.CloseCurrentStream();
         }


### PR DESCRIPTION
Closes #11

## 문제

한글 문서에 삽입된 메모가 라이브러리로 읽히지 않는 문제를 수정합니다 (#11).

원인은 Java 원본(hwplib)의 `reader/bodytext/memo/ForMemo.java`, `ForMemoList.java`가 C# 포팅에서 누락되어, 마지막 섹션 스트림 끝에 붙는 `MEMO_LIST` 레코드를 아무도 소비하지 않고 버리고 있었기 때문입니다. 문단 읽기 루프의 `IsFollowMemo()`는 이미 포팅되어 있어 메모 레코드 앞에서 정확히 멈추지만, 그 뒤 처리가 없었습니다.

## 변경 사항

- **Reader**: `Reader/BodyText/Memo/ForMemo.cs`, `ForMemoList.cs` 신규 포팅. `HWPReader`가 마지막 섹션을 읽은 뒤 `MEMO_LIST` 레코드들을 `BodyText.MemoList`로 읽어들입니다 (Java `HWPReader.memo()` 미러링).
- **Writer**: `HWPWriter.WriteSection`의 주석 처리된 메모 쓰기 TODO 블록을 활성화하여 라운드트립 시 메모가 보존됩니다.
- **AutoSetter**: 메모 문단 리스트도 자동 설정하도록 확장. 이것이 없으면 프로그래밍 방식으로 만든 메모 문단의 `CharacterCount`가 0으로 남아, Writer가 **크기 0의 PARA_TEXT 레코드 + 본문 바이트**를 기록해 파일이 깨집니다. (Java 원본에도 동일한 공백이 있으나, 쓰기 지원을 활성화하는 이상 필요한 보완입니다.)
- **Reader 견고성**: 크기 0 레코드를 만나면 헤더 플래그가 소비되지 않아 문단 읽기 루프가 무한 루프에 빠지는 문제를 방지했습니다 (손상된 파일에서 리더가 멈추지 않도록).

## 사용 방법 (이슈 #11 시나리오)

메모는 문단이 아니라 문서 수준에 달려 있습니다. Java 원본과 동일하게 `TextExtractor.Extract`는 메모 본문을 포함하지 않으며, 다음과 같이 접근합니다:

```csharp
var hwpFile = HWPReader.FromFile("문서.hwp");
if (hwpFile.BodyText.MemoList != null)
{
    foreach (var memo in hwpFile.BodyText.MemoList)
    {
        Console.WriteLine(memo.ParagraphList.GetNormalString());
    }
}
```

## 테스트

- 메모 라운드트립 테스트 3건 추가 (`ReadingWritingMemoTest`): 단일 메모, 다중 메모, 텍스트 추출
- 전체 테스트: net8.0 / net472 각 162개 전부 통과 (회귀 없음)

참고: 저장소에 한글에서 저장한 메모 포함 샘플 HWP가 없어, 자체 Writer로 생성한 파일의 라운드트립으로 검증했습니다. 이슈 작성자의 한글 2020 파일로 추가 검증이 가능하면 더 확실합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)