### PR TITLE
hwplib 업스트림 d9e073d6 동기화 및 1.1.10.8 버전 업데이트

### DIFF
--- a/src/hwplibsharp/Reader/DocInfo/BorderFill/ForFillInfo.cs
+++ b/src/hwplibsharp/Reader/DocInfo/BorderFill/ForFillInfo.cs
@@ -109,8 +109,8 @@ namespace HwpLib.Reader.DocInfo.BorderFill
         /// <param name="sr">스트림 리더</param>
         public static void ReadPictureInfo(PictureInfo pi, CompoundStreamReader sr)
         {
-            pi.Brightness = sr.ReadSInt1();
             pi.Contrast = sr.ReadSInt1();
+            pi.Brightness = sr.ReadSInt1();
             pi.Effect = PictureEffectExtensions.FromValue(sr.ReadUInt1());
             pi.BinItemID = sr.ReadUInt2();
         }

--- a/src/hwplibsharp/Writer/DocInfo/BorderFill/ForFillInfo.cs
+++ b/src/hwplibsharp/Writer/DocInfo/BorderFill/ForFillInfo.cs
@@ -108,8 +108,8 @@ namespace HwpLib.Writer.DocInfo.BorderFill
         /// <param name="sw">스트림 라이터</param>
         public static void PictureInfo(PictureInfo pi, CompoundStreamWriter sw)
         {
-            sw.WriteSInt1(pi.Brightness);
             sw.WriteSInt1(pi.Contrast);
+            sw.WriteSInt1(pi.Brightness);
             sw.WriteUInt1((byte)pi.Effect);
             sw.WriteUInt2(pi.BinItemID);
         }

--- a/src/hwplibsharp/hwplibsharp.csproj
+++ b/src/hwplibsharp/hwplibsharp.csproj
@@ -11,9 +11,9 @@
 		<Prefer32Bit>false</Prefer32Bit>
 
 		<!-- Version Information -->
-		<Version>1.1.10.7</Version>
-		<AssemblyVersion>1.1.10.7</AssemblyVersion>
-		<FileVersion>1.1.10.7</FileVersion>
+		<Version>1.1.10.8</Version>
+		<AssemblyVersion>1.1.10.8</AssemblyVersion>
+		<FileVersion>1.1.10.8</FileVersion>
 
 		<!-- Package Metadata -->
 		<PackageId>HwpLibSharp</PackageId>


### PR DESCRIPTION
Closes #12

## 변경 사항

업스트림 hwplib의 새 커밋 **d9e073d6** 을 분석하여 반영했습니다.

### 1. FillInfo PictureInfo 바이트 순서 교정 (실질 변경)

`BorderFill`의 그림 채우기 정보에서 `contrast`/`brightness`를 읽고 쓰는 순서가 HWP 파일 형식과 반대로 되어 있던 것을 업스트림과 동일하게 교정했습니다 (contrast 먼저, brightness 다음).

- `Reader/DocInfo/BorderFill/ForFillInfo.cs` — `ReadPictureInfo`
- `Writer/DocInfo/BorderFill/ForFillInfo.cs` — `PictureInfo`

읽기/쓰기가 대칭으로 수정되어 라운드트립 동작에는 영향이 없고, 실제 한글 파일과의 필드 해석이 올바르게 됩니다.

### 2. 반영 불필요 항목 확인

- **About.java** (버전 문자열 1.1.7 → 1.1.10): C#에서는 csproj 버전으로 관리되므로 해당 없음
- **이슈 #303 관련 HWPReader 수정** (커밋 메시지에 언급): 실제 코드 변경은 이전 커밋 feff19ee에 있으며, C# `ReadScripts()`에 try/catch로 이미 반영되어 있음을 확인

### 3. 서브모듈 및 버전

- `hwplib` 서브모듈 포인터를 `origin/main(d9e073d6)`으로 업데이트
- 라이브러리 버전 1.1.10.7 → **1.1.10.8** (메모 지원 #13 + 본 동기화 포함, 다음 릴리스 준비)

## 테스트

- 전체 테스트: net8.0 / net472 각 162개 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)