### PR TITLE
NuGet 릴리스를 Trusted Publishing(OIDC) 방식으로 전환

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ jobs:
     # Windows runner is required for .NET Framework 4.7.2 target
     runs-on: windows-latest
 
+    permissions:
+      # NuGet Trusted Publishing(OIDC)을 위한 GitHub OIDC 토큰 발급 권한
+      id-token: write
+      contents: read
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -30,9 +35,16 @@ jobs:
     - name: Pack
       run: dotnet pack --no-build --configuration Release --output ./nupkgs
 
+    # OIDC 토큰을 1시간 유효한 임시 API 키로 교환 (푸시 직전에 실행해야 함)
+    - name: NuGet login (Trusted Publishing)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: rkttu
+
     - name: Push to NuGet
       run: |
         foreach ($pkg in Get-ChildItem -Path ./nupkgs -Filter *.nupkg) {
-          dotnet nuget push $pkg.FullName --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push $pkg.FullName --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         }
       shell: pwsh


### PR DESCRIPTION
## 변경 사항

`release.yml`의 NuGet 배포 인증을 장기 보관 API 키(`NUGET_API_KEY` 시크릿)에서 **Trusted Publishing(OIDC)** 방식으로 전환합니다.

- 잡에 `permissions: id-token: write` 추가 (GitHub OIDC 토큰 발급 허용, `contents: read`는 checkout용으로 명시)
- `NuGet/login@v1` 액션으로 OIDC 토큰을 **1시간 유효한 임시 API 키**로 교환
  - 임시 키 만료를 피하기 위해 Pack 이후, Push 직전에 배치
  - `user: rkttu` — nuget.org 프로필명 (HwpLibSharp 패키지 소유자 확인 완료)
- `dotnet nuget push`의 `--api-key`를 `steps.nuget-login.outputs.NUGET_API_KEY`로 교체

## 전제 조건 (완료됨)

nuget.org의 Trusted Publishing 정책이 다음과 같이 등록되어 있어야 합니다:
- Repository Owner: `rkttu` / Repository: `hwplibsharp` / Workflow File: `release.yml`
- Environment는 워크플로에서 사용하지 않으므로 비워 두어야 합니다

## 머지 후 안내

- 저장소의 `NUGET_API_KEY` 시크릿은 더 이상 사용되지 않으므로 삭제해도 됩니다
- 실제 검증은 다음 GitHub Release 발행 시 이루어집니다 (릴리스 워크플로는 release published 이벤트에서만 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)