### PR TITLE
릴리스 워크플로에 production environment 지정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
     # Windows runner is required for .NET Framework 4.7.2 target
     runs-on: windows-latest
 
+    # nuget.org Trusted Publishing 정책의 Environment 설정과 일치해야 함
+    environment: production
+
     permissions:
       # NuGet Trusted Publishing(OIDC)을 위한 GitHub OIDC 토큰 발급 권한
       id-token: write


### PR DESCRIPTION
## 변경 사항

`release.yml`의 `build-test-publish` 잡에 `environment: production`을 추가합니다.

nuget.org Trusted Publishing 정책에 Environment가 `production`으로 설정되어 있으므로, OIDC 토큰의 environment 클레임이 정책과 일치해야 임시 API 키 교환이 성공합니다.

참고: 저장소에 `production` environment가 아직 없으면 워크플로 첫 실행 시 자동 생성됩니다(보호 규칙 없음 상태). 필요 시 Settings → Environments에서 승인자 지정 등 보호 규칙을 추가할 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)